### PR TITLE
Improve settings modal responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,12 @@
     .modal-backdrop {
       position: fixed; inset: 0; background: rgba(2,6,23,0.5); display: none; align-items: center; justify-content: center; z-index: 50;
     }
-    .modal { background: var(--card); border-radius: 14px; box-shadow: var(--shadow); padding: 14px; max-width: 720px; width: calc(100% - 24px); border: 1px solid rgba(100,116,139,0.2); }
+    .modal {
+      background: var(--card); border-radius: 14px; box-shadow: var(--shadow);
+      padding: 14px; max-width: 720px; width: calc(100% - 24px);
+      border: 1px solid rgba(100,116,139,0.2);
+      max-height: 90vh; overflow-y: auto;
+    }
     .modal h3 { margin-top: 0; }
 
     .snackbar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 16px; background: var(--card); color: var(--text); border: 1px solid rgba(100,116,139,0.25); border-radius: 999px; padding: 10px 14px; display: none; align-items: center; gap: 10px; z-index: 60; box-shadow: var(--shadow); }


### PR DESCRIPTION
## Summary
- allow the settings modal to scroll by limiting its height and enabling overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3676cbdb483339728956ab946310d