### PR TITLE
Enable automatic asset refresh without cache name bumps

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -7,13 +7,20 @@ const ASSETS = [
   './manifest.webmanifest'
 ];
 
+// Install the service worker and precache the core assets. Calling
+// `skipWaiting()` lets the new worker take control immediately without
+// requiring a cache name bump.
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
   );
 });
 
+// Clean up old caches and make the service worker take control of clients
+// right away so updates are applied without manual refreshes.
 self.addEventListener('activate', event => {
+  self.clients.claim();
   event.waitUntil(
     caches.keys().then(keys => Promise.all(
       keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
@@ -21,8 +28,20 @@ self.addEventListener('activate', event => {
   );
 });
 
+// Use a network-first strategy so that updates to cached assets are fetched
+// automatically without needing to change the cache name. Successful network
+// responses update the cache; if the network is unavailable, the cached
+// response is used as a fallback.
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
-    caches.match(event.request).then(res => res || fetch(event.request))
+    fetch(event.request)
+      .then(response => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- allow service worker to take control immediately and clean old caches
- use a network-first strategy to refresh cached assets without changing cache name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b334d9abf4833390b4ed2e719bcfd1