### PR TITLE
Rename pain log trigger and show confirmation toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,8 @@
 
     .snackbar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 16px; background: var(--card); color: var(--text); border: 1px solid rgba(100,116,139,0.25); border-radius: 999px; padding: 10px 14px; display: none; align-items: center; gap: 10px; z-index: 60; box-shadow: var(--shadow); }
 
+    .toast { position: fixed; top: 16px; right: 16px; background: var(--card); color: var(--text); border: 1px solid rgba(100,116,139,0.25); border-radius: 8px; padding: 10px 14px; display: none; z-index: 60; box-shadow: var(--shadow); }
+
     .tooltip { position: absolute; pointer-events: none; background: var(--card); border: 1px solid rgba(100,116,139,0.25); color: var(--text); padding: 6px 8px; border-radius: 8px; box-shadow: var(--shadow-sm); font-size: 12px; display: none; z-index: 40; }
 
     .canvas-wrap { position: relative; }
@@ -338,7 +340,7 @@
           <div class="row" style="align-items:center;">
             <div class="help">Öppna bladet för att registrera ett tillfälle.</div>
             <div class="spacer"></div>
-            <button id="openPainSheet" class="btn ok" type="button" title="Öppna smärtblad">Öppna blad</button>
+            <button id="openPainSheet" class="btn ok" type="button" title="Ny smärtlogg">Ny logg</button>
           </div>
         </div>
 
@@ -723,6 +725,7 @@
     </div>
   </div>
 
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
   <div id="snackbar" class="snackbar" role="status" aria-live="polite">
     <span id="snackText"></span>
     <button id="snackUndo" class="btn ghost">Ångra</button>
@@ -1639,6 +1642,7 @@
           els.snackbar = document.getElementById('snackbar');
           els.snackText = document.getElementById('snackText');
           els.snackUndo = document.getElementById('snackUndo');
+          els.toast = document.getElementById('toast');
         }
 
         function bind() {
@@ -1770,6 +1774,7 @@
           State.pain.sort((a,b)=>b.timestamp.localeCompare(a.timestamp));
           Storage.saveAll(State);
           announce('Smärta sparad.');
+          showToast('Smärttillfälle inlagt');
           // reset vissa fält
           els.painNote.value='';
           if (els.painEnd) els.painEnd.value='';
@@ -1972,6 +1977,14 @@
           els.snackbar.style.display = 'flex';
           clearTimeout(showSnack._t);
           showSnack._t = setTimeout(()=>{ els.snackbar.style.display = 'none'; State.lastDeleted=null; }, 5000);
+        }
+
+        function showToast(text) {
+          if (!els.toast) return;
+          els.toast.textContent = text;
+          els.toast.style.display = 'block';
+          clearTimeout(showToast._t);
+          showToast._t = setTimeout(()=>{ els.toast.style.display = 'none'; }, 3000);
         }
 
         function undoDelete() {
@@ -2380,6 +2393,8 @@
         const panel = backdrop.querySelector('.sheet'); panel?.classList.remove('open');
         document.body.style.overflow = '';
       }
+      window.openSheet = openSheet;
+      window.closeSheet = closeSheet;
       // Stängknappar
       [
         ['painSheet','closePainSheet'],['painSheet','closePainSheet2'],


### PR DESCRIPTION
## Summary
- Rename "Öppna blad" button to "Ny logg"
- Show top-right toast confirming new pain log and close sheet after submit
- Expose sheet helpers globally for reliable closing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b367c8e5f083339d3a33e8639625ed