### PR TITLE
Add animated green toast and adjust pain level colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,15 @@
 
     .snackbar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 16px; background: var(--card); color: var(--text); border: 1px solid rgba(100,116,139,0.25); border-radius: 999px; padding: 10px 14px; display: none; align-items: center; gap: 10px; z-index: 60; box-shadow: var(--shadow); }
 
-    .toast { position: fixed; top: 16px; right: 16px; background: var(--card); color: var(--text); border: 1px solid rgba(100,116,139,0.25); border-radius: 8px; padding: 10px 14px; display: none; z-index: 60; box-shadow: var(--shadow); }
+    .toast {
+      position: fixed; top: 16px; right: 16px;
+      background: var(--ok); color: #fff;
+      border: 1px solid rgba(100,116,139,0.25); border-radius: 8px;
+      padding: 10px 14px; display: none; z-index: 60; box-shadow: var(--shadow);
+      opacity: 0; transform: translateY(-10px);
+      transition: opacity var(--duration) ease, transform var(--duration) ease;
+    }
+    .toast.show { opacity: 1; transform: translateY(0); }
 
     .tooltip { position: absolute; pointer-events: none; background: var(--card); border: 1px solid rgba(100,116,139,0.25); color: var(--text); padding: 6px 8px; border-radius: 8px; box-shadow: var(--shadow-sm); font-size: 12px; display: none; z-index: 40; }
 
@@ -974,9 +982,15 @@
           return [Math.round(r*255), Math.round(g*255), Math.round(b*255)];
         }
         function levelColor(level) {
-          // 1..10 -> färgskala från lila till rosa/röd
-          const t = (level-1)/9; // 0..1
-          const [r,g,b] = hsvToRgb(0.9 - t*0.55, 0.65 + 0.2*t, 0.95); // violet -> pink/red-ish
+          // 1..10 -> färgskala från grön via gul till röd
+          level = clamp(level, 1, 10);
+          let hueDeg;
+          if (level <= 5) {
+            hueDeg = 120 - (level - 1) * 15; // 120 -> 60
+          } else {
+            hueDeg = 60 - (level - 5) * 12; // 60 -> 0
+          }
+          const [r,g,b] = hsvToRgb(hueDeg / 360, 1, 0.9);
           return `rgb(${r},${g},${b})`;
         }
         function escCsv(s) {
@@ -1983,8 +1997,13 @@
           if (!els.toast) return;
           els.toast.textContent = text;
           els.toast.style.display = 'block';
+          requestAnimationFrame(() => els.toast.classList.add('show'));
           clearTimeout(showToast._t);
-          showToast._t = setTimeout(()=>{ els.toast.style.display = 'none'; }, 3000);
+          clearTimeout(showToast._hideT);
+          showToast._t = setTimeout(() => {
+            els.toast.classList.remove('show');
+            showToast._hideT = setTimeout(() => { els.toast.style.display = 'none'; }, 200);
+          }, 3000);
         }
 
         function undoDelete() {


### PR DESCRIPTION
## Summary
- Animate toast notification and style it green
- Use green-to-red gradient with yellow midpoint for pain levels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36c547ee483339a4c6f8c44642804