### PR TITLE
Adjust level color scale and add toasts for pee and fluid

### DIFF
--- a/index.html
+++ b/index.html
@@ -982,13 +982,13 @@
           return [Math.round(r*255), Math.round(g*255), Math.round(b*255)];
         }
         function levelColor(level) {
-          // 1..10 -> färgskala från grön via gul till röd
+          // 1..10 -> färgskala från rosa via lila till blå
           level = clamp(level, 1, 10);
           let hueDeg;
           if (level <= 5) {
-            hueDeg = 120 - (level - 1) * 15; // 120 -> 60
+            hueDeg = 330 - (level - 1) * 15; // 330 -> 270
           } else {
-            hueDeg = 60 - (level - 5) * 12; // 60 -> 0
+            hueDeg = 270 - (level - 5) * 12; // 270 -> 210
           }
           const [r,g,b] = hsvToRgb(hueDeg / 360, 1, 0.9);
           return `rgb(${r},${g},${b})`;
@@ -2022,13 +2022,13 @@
           const now = new Date(); now.setSeconds(0,0);
           const iso = Utils.toLocalISO(now);
           State.pee.unshift({ id: Utils.newUUID(), timestamp: iso });
-          Storage.saveAll(State); renderPeeList(); Charts.rebuildAll(); announce('Kiss sparad.');
+          Storage.saveAll(State); renderPeeList(); Charts.rebuildAll(); announce('Kiss sparad.'); showToast('Kiss registrerat');
         }
         function addPeeCustom() {
           const d = els.peeDate.value; const t = els.peeTime.value; if (!d || !t) { announce('Välj datum och tid.'); return; }
           const iso = Utils.toLocalISO(Utils.fromDateTimeStrings(d,t));
           State.pee.unshift({ id: Utils.newUUID(), timestamp: iso });
-          Storage.saveAll(State); renderPeeList(); Charts.rebuildAll(); announce('Kiss sparad.');
+          Storage.saveAll(State); renderPeeList(); Charts.rebuildAll(); announce('Kiss sparad.'); showToast('Kiss registrerat');
         }
         function renderPeeList() {
           const list = els.peeList; list.innerHTML = '';
@@ -2066,7 +2066,7 @@
           const iso = Utils.toLocalISO(Utils.fromDateTimeStrings(d,t));
           const dryck = els.fluidType.value.trim();
           State.fluid.unshift({ id: Utils.newUUID(), timestamp: iso, volym_ml: vol, dryck });
-          Storage.saveAll(State); renderFluidList(); Charts.rebuildAll(); announce('Vätska tillagd.');
+          Storage.saveAll(State); renderFluidList(); Charts.rebuildAll(); announce('Vätska tillagd.'); showToast('Vätska registrerad');
           e.target.reset(); els.fluidDate.value = d; els.fluidTime.value = t; // behåll tid/datum
         }
         function renderFluidList() {


### PR DESCRIPTION
## Summary
- Update pain level color mapping to transition from pink through purple to blue
- Show confirmation toasts when registering pee or fluid entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b36fb2f304833391e12eb5a482964a