### PR TITLE
Fix: prevent horizontal swipe on pain logging sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
     .sheet { background: var(--card); color: var(--text); width: 100%; max-width: 720px; max-height: 90vh; border-top-left-radius: var(--radius-xl); border-top-right-radius: var(--radius-xl); box-shadow: var(--shadow-lg); transform: translateY(100%); transition: transform var(--duration) ease; border: 1px solid rgba(100,116,139,0.2); }
     .sheet.open { transform: translateY(0); }
     .sheet .sheet-header { position: sticky; top: 0; background: var(--card); padding: 14px 16px; border-bottom: 1px solid rgba(100,116,139,0.15); border-top-left-radius: var(--radius-xl); border-top-right-radius: var(--radius-xl); display: flex; align-items: center; gap: 8px; }
-    .sheet .sheet-body { padding: 12px 16px 80px; overflow: auto; max-height: calc(90vh - 120px); }
+    .sheet .sheet-body { padding: 12px 16px 80px; overflow-y: auto; overflow-x: hidden; max-height: calc(90vh - 120px); touch-action: pan-y; }
     .sheet .sheet-actions { position: sticky; bottom: 0; background: linear-gradient(to top, var(--card), rgba(0,0,0,0)); padding: 10px 16px 16px; display: flex; gap: 10px; justify-content: flex-end; }
 
     /* Focus visibility */


### PR DESCRIPTION
## Summary
- prevent horizontal swipe on sheet content for pain logging by limiting touch gestures to vertical

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37282652c8333baf36508f9c6161a