### PR TITLE
Align pain sections width with global reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,10 @@
       --chip-selected-fg: #ffffff;
     }
 
-    * { box-sizing: border-box; }
+    *,*::before,*::after{ box-sizing:border-box; }
+    details,summary,fieldset,legend{ margin:0; padding:0; }
+    summary{ list-style:none; }
+    summary::-webkit-details-marker{ display:none; }
     html, body { height: 100%; }
     body {
       margin: 0;
@@ -161,8 +164,8 @@
     .btn[disabled] { opacity: 0.6; cursor: not-allowed; }
 
     main { max-width: 1000px; margin: 10px auto 120px; padding: 0 16px; }
-    .page { max-width: 480px; margin: 0 auto; padding: 0 var(--s2); }
-    .section { width: 100%; padding: var(--s2); border-radius: var(--rad); }
+    .page{ max-width:480px; margin-inline:auto; padding-inline:16px; }
+    .section{ width:100%; padding:16px; border-radius:16px; margin-top:24px; }
 
     .tabs { display: none !important; }
     .tabs .tablist { display: none; }
@@ -213,8 +216,8 @@
     .muted { color: var(--muted); }
     .help { font-size: 12px; color: var(--muted); }
 
-    .filters details { border: 1px dashed rgba(100,116,139,0.4); border-radius: 10px; padding: 10px; }
-    .filters summary { cursor: pointer; font-weight: 700; }
+    .section.filters{ border:1px dashed rgba(100,116,139,0.4); }
+    .section.filters summary{ cursor:pointer; font-weight:700; }
 
     .banner { background: var(--surface); padding: 8px 12px; border-radius: 10px; font-size: 13px; }
 
@@ -347,107 +350,103 @@
 
     <!-- Smärta -->
     <section id="tab-smarta" role="tabpanel" aria-labelledby="tabbtn-smarta">
-      <div class="grid grid-2">
-        <div class="card" id="painFormCard">
-          <h3>Logga smärta</h3>
-          <div class="row" style="align-items:center;">
-            <div class="help">Öppna bladet för att registrera ett tillfälle.</div>
-            <div class="spacer"></div>
-            <button id="openPainSheet" class="btn ok" type="button" title="Ny smärtlogg">Ny logg</button>
-          </div>
+      <section class="section card" id="painFormCard">
+        <h3>Logga smärta</h3>
+        <div class="row" style="align-items:center;">
+          <div class="help">Öppna bladet för att registrera ett tillfälle.</div>
+          <div class="spacer"></div>
+          <button id="openPainSheet" class="btn ok" type="button" title="Ny smärtlogg">Ny logg</button>
         </div>
+      </section>
 
-        <div class="card filters">
-          <details>
-            <summary>Filter & sök</summary>
-            <form id="painFilters" style="margin-top:10px;">
-              <div class="row">
-                <div>
-                  <label for="fFrom">Från</label>
-                  <input id="fFrom" type="date" />
-                </div>
-                <div>
-                  <label for="fTo">Till</label>
-                  <input id="fTo" type="date" />
+      <section class="section card filters">
+        <details>
+          <summary>Filter & sök</summary>
+          <form id="painFilters" style="margin-top:10px;">
+            <div class="row">
+              <div>
+                <label for="fFrom">Från</label>
+                <input id="fFrom" type="date" />
+              </div>
+              <div>
+                <label for="fTo">Till</label>
+                <input id="fTo" type="date" />
+              </div>
+            </div>
+            <div class="row">
+              <div>
+                <label>Typ</label>
+                <div class="row">
+                  <label><input type="checkbox" id="fMagont" checked /> Magont</label>
+                  <label><input type="checkbox" id="fLivmoder" checked /> Livmoder‑ont</label>
                 </div>
               </div>
-              <div class="row">
-                <div>
-                  <label>Typ</label>
-                  <div class="row">
-                    <label><input type="checkbox" id="fMagont" checked /> Magont</label>
-                    <label><input type="checkbox" id="fLivmoder" checked /> Livmoder‑ont</label>
-                  </div>
-                </div>
-                <div>
-                  <label>Nivåintervall</label>
-                  <div class="row">
-                    <input type="number" id="fMin" min="1" max="10" value="1" />
-                    <input type="number" id="fMax" min="1" max="10" value="10" />
-                  </div>
+              <div>
+                <label>Nivåintervall</label>
+                <div class="row">
+                  <input type="number" id="fMin" min="1" max="10" value="1" />
+                  <input type="number" id="fMax" min="1" max="10" value="10" />
                 </div>
               </div>
-              <div class="row">
-                <div>
-                  <label for="fMeds">Läkemedel</label>
-                  <select id="fMeds">
-                    <option value="alla">Alla</option>
-                    <option value="har">Har</option>
-                    <option value="harinte">Har inte</option>
-                  </select>
-                </div>
-                <div>
-                  <label for="fEffekt">Effekt</label>
-                  <select id="fEffekt">
-                    <option value="alla">Alla</option>
-                    <option value="ja">Ja</option>
-                    <option value="delvis">Delvis</option>
-                    <option value="nej">Nej</option>
-                    <option value="vet ej">Vet ej</option>
-                  </select>
-                </div>
+            </div>
+            <div class="row">
+              <div>
+                <label for="fMeds">Läkemedel</label>
+                <select id="fMeds">
+                  <option value="alla">Alla</option>
+                  <option value="har">Har</option>
+                  <option value="harinte">Har inte</option>
+                </select>
               </div>
-              <div class="row">
-                <div>
-                  <label for="fSok">Söktext (anteckning)</label>
-                  <input id="fSok" type="text" placeholder="t.ex. knip" />
-                </div>
-                <div class="row" style="align-items: flex-end;">
-                  <button class="btn ghost" id="btnClrFilter" type="button">Nollställ</button>
-                  <button class="btn" id="btnApplyFilter" type="button">Använd</button>
-                </div>
+              <div>
+                <label for="fEffekt">Effekt</label>
+                <select id="fEffekt">
+                  <option value="alla">Alla</option>
+                  <option value="ja">Ja</option>
+                  <option value="delvis">Delvis</option>
+                  <option value="nej">Nej</option>
+                  <option value="vet ej">Vet ej</option>
+                </select>
               </div>
-            </form>
-          </details>
+            </div>
+            <div class="row">
+              <div>
+                <label for="fSok">Söktext (anteckning)</label>
+                <input id="fSok" type="text" placeholder="t.ex. knip" />
+              </div>
+              <div class="row" style="align-items: flex-end;">
+                <button class="btn ghost" id="btnClrFilter" type="button">Nollställ</button>
+                <button class="btn" id="btnApplyFilter" type="button">Använd</button>
+              </div>
+            </div>
+          </form>
+        </details>
+      </section>
+
+      <section class="section card">
+        <h3>Lista</h3>
+        <div id="painList" class="list-group" aria-live="polite"></div>
+        <div id="painEmpty" class="muted" hidden>Inget registrerat ännu. Lägg till i formuläret ovan.</div>
+      </section>
+
+      <section class="section card">
+        <h3>Grafik</h3>
+        <div class="canvas-wrap">
+          <canvas id="painLine"></canvas>
         </div>
-      </div>
-
-      <div class="grid grid-2" style="margin-top:10px;">
-        <div class="card">
-          <h3>Lista</h3>
-          <div id="painList" class="list-group" aria-live="polite"></div>
-          <div id="painEmpty" class="muted" hidden>Inget registrerat ännu. Lägg till i formuläret ovan.</div>
+        <div class="canvas-wrap" style="margin-top:10px;">
+          <canvas id="painBars"></canvas>
         </div>
-        <div class="card">
-          <h3>Grafik</h3>
-          <div class="canvas-wrap">
-            <canvas id="painLine"></canvas>
-          </div>
-          <div class="canvas-wrap" style="margin-top:10px;">
-            <canvas id="painBars"></canvas>
-          </div>
-          <div class="canvas-wrap" style="margin-top:10px;">
-            <canvas id="painMeds"></canvas>
-          </div>
-          <div class="canvas-wrap" style="margin-top:10px;">
-            <canvas id="painBox"></canvas>          </div>          <div class="canvas-wrap" style="margin-top:10px;">
-            <canvas id="painDuration"></canvas>
-          </div>
-
-
-
+        <div class="canvas-wrap" style="margin-top:10px;">
+          <canvas id="painMeds"></canvas>
         </div>
-      </div>
+        <div class="canvas-wrap" style="margin-top:10px;">
+          <canvas id="painBox"></canvas>
+        </div>
+        <div class="canvas-wrap" style="margin-top:10px;">
+          <canvas id="painDuration"></canvas>
+        </div>
+      </section>
     </section>
 
     <!-- Kiss -->


### PR DESCRIPTION
## Summary
- add global CSS reset and page container rules
- move pain log, filter & search, and list into unified sections
- style filter dashed border on section and ensure consistent width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3755bf8c48333bb0058b7887b6aed