### PR TITLE
Fix list card overflow and ensure full-width layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,10 @@
     .list-day { margin-top: 12px; }
     .list-day > .day-head { font-weight: 800; color: var(--muted); margin: 6px 4px; }
 
+    .list{ width:100%; max-width:100%; overflow-x:hidden; }
+    .list .card, .list .entry{ width:100%; max-width:100%; margin-inline:0; box-sizing:border-box; }
+    .list .card > *{ min-width:0; } /* tillåt innehåll att krympa i flex/grid */
+
     .item { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; background: var(--card); border: 1px solid rgba(100,116,139,0.2); padding: 10px; border-radius: 12px; box-shadow: var(--shadow-sm); }
     .item .meta { font-size: 12px; color: var(--muted); }
     .item .actions { display: flex; gap: 6px; }


### PR DESCRIPTION
## Summary
- Add CSS constraints so `.list` and its cards fill the page width without horizontal overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b377d943688333bac90d2ba0a5b780