### PR TITLE
Clamp layout and prevent list overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="sv" data-theme="light">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Magen – Smärta, Kiss & Vätska</title>
 
   <!-- Ikoner -->
@@ -120,9 +120,11 @@
     }
 
     *,*::before,*::after{ box-sizing:border-box; }
-    details,summary,fieldset,legend{ margin:0; padding:0; }
+    html{ -webkit-text-size-adjust:100%; }
+    details,summary{ margin:0; padding:0; }
     summary{ list-style:none; }
     summary::-webkit-details-marker{ display:none; }
+    fieldset,legend{ margin:0; padding:0; }
     html, body { height: 100%; }
     body {
       margin: 0;
@@ -164,8 +166,9 @@
     .btn[disabled] { opacity: 0.6; cursor: not-allowed; }
 
     main { max-width: 1000px; margin: 10px auto 120px; padding: 0 16px; }
-    .page{ max-width:480px; margin-inline:auto; padding-inline:16px; }
-    .section{ width:100%; padding:16px; border-radius:16px; margin-top:24px; }
+    .page{ max-width:480px; width:100%; margin-inline:auto; padding-inline:max(16px, env(safe-area-inset-left)); padding-right:max(16px, env(safe-area-inset-right)); }
+    .section{ width:100%; max-width:100%; padding:16px; border-radius:16px; margin-top:24px; }
+    .section.card{ box-sizing:border-box; }
 
     .tabs { display: none !important; }
     .tabs .tablist { display: none; }
@@ -205,12 +208,18 @@
     .list-day > .day-head { font-weight: 800; color: var(--muted); margin: 6px 4px; }
 
     .list{ width:100%; max-width:100%; overflow-x:hidden; }
-    .list .card, .list .entry{ width:100%; max-width:100%; margin-inline:0; box-sizing:border-box; }
-    .list .card > *{ min-width:0; } /* tillåt innehåll att krympa i flex/grid */
+    .list .card, .list .entry{ width:100%; max-width:100%; margin-inline:0; }
+    .list .card > *{ min-width:0; } /* flex/grid-barn får krympa */
 
     .item { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; background: var(--card); border: 1px solid rgba(100,116,139,0.2); padding: 10px; border-radius: 12px; box-shadow: var(--shadow-sm); }
     .item .meta { font-size: 12px; color: var(--muted); }
-    .item .actions { display: flex; gap: 6px; }
+    .item .actions { display:flex; gap:8px; flex-wrap:nowrap; min-width:0; }
+    .item .actions button{ white-space:nowrap; }
+
+    @media (max-width:400px){
+      .item .actions{ flex-wrap:wrap; } /* knappar bryter istället för att trycka ut kortet */
+      .item .actions button{ flex:1 1 auto; }
+    }
 
     .level-badge {
       display: inline-flex; align-items: center; justify-content: center; min-width: 34px; padding: 4px 8px; border-radius: 999px; color: white; font-weight: 800; font-size: 12px;


### PR DESCRIPTION
## Summary
- Stabilize PWA viewport and text sizing for iOS
- Clamp page sections to safe-area width and harden details/summary defaults
- Prevent list items and action buttons from overflowing, with mobile wrapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b426e9cc308333bf8ca0c3104d8671