### PR TITLE
Stack log card actions vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,15 +221,10 @@
     .list .card, .list .entry{ width:100%; max-width:100%; margin-inline:0; }
     .list .card > *{ min-width:0; } /* flex/grid-barn får krympa */
 
-    .item { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; background: var(--card); border: 1px solid rgba(100,116,139,0.2); padding: 10px; border-radius: 12px; box-shadow: var(--shadow-sm); }
+    .item { display: grid; grid-template-columns: 1fr 110px; gap: 10px; align-items: start; background: var(--card); border: 1px solid rgba(100,116,139,0.2); padding: 10px; border-radius: 12px; box-shadow: var(--shadow-sm); }
     .item .meta { font-size: 12px; color: var(--muted); }
-    .item .actions { display:flex; gap:8px; flex-wrap:nowrap; min-width:0; }
-    .item .actions button{ white-space:nowrap; }
-
-    @media (max-width:400px){
-      .item .actions{ flex-wrap:wrap; } /* knappar bryter istället för att trycka ut kortet */
-      .item .actions button{ flex:1 1 auto; }
-    }
+    .item .actions { display:flex; flex-direction:column; gap:8px; }
+    .item .actions button{ white-space:nowrap; width:100%; }
 
     .level-badge {
       display: inline-flex; align-items: center; justify-content: center; min-width: 34px; padding: 4px 8px; border-radius: 999px; color: white; font-weight: 800; font-size: 12px; margin-left:8px; background:var(--accent);
@@ -2166,7 +2161,8 @@
               const right = document.createElement('div'); right.className='actions';
               const btnDel = buttonSmall('Ta bort', 'danger', ()=>deleteFluid(it.id));
               const div = document.createElement('div'); div.className='item'; div.setAttribute('data-id', it.id);
-              div.append(left, right.appendChild(btnDel), right); // ensure correct structure
+              right.append(btnDel);
+              div.append(left, right);
               wrap.appendChild(div);
             }
             list.appendChild(wrap);


### PR DESCRIPTION
## Summary
- Stack Edit, Duplicate, and Delete buttons vertically in log cards
- Fix fluid log rendering to correctly append action buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4290f18a4833395bdf62e559e30a4