### PR TITLE
style: improve fluid sheet layout and pin action row

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
     .sheet .sheet-body { padding: 12px 16px 80px; overflow-y: auto; overflow-x: hidden; max-height: calc(90vh - 120px); touch-action: pan-y; }
     .sheet .sheet-actions{
       position: sticky; bottom: 0;
-      background: linear-gradient(to top, var(--card) 60%, rgba(0,0,0,0));
+      background: var(--card);
       padding: 12px 0 8px;
       display:flex; gap:10px; justify-content:flex-end;
     }
@@ -753,7 +753,7 @@
         <button class="btn ghost" type="button" id="closeFluidSheet">Stäng</button>
       </div>
       <div class="sheet-body">
-        <form id="fluidForm">
+        <form id="fluidForm" class="form-grid">
           <div class="row-date">
             <div class="field-card">
               <label for="fluidDate">Datum</label>


### PR DESCRIPTION
## Summary
- add `form-grid` layout to fluid logging sheet for breathing space
- give sheet action bar a solid background so buttons stay pinned and content doesn't show through

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4386ebd2483339858819a42db9ce4