### PR TITLE
Close stool planning sheet after adding entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -2569,6 +2569,7 @@
           State.stool.unshift({ id: Utils.newUUID(), timestamp: iso, bristol: b, anteckning: note });
           Storage.saveAll(State); renderStoolList(); announce('Avföring sparad.'); showToast('Avföring registrerad');
           if (els.stoolDate && els.stoolTime) { setNow(els.stoolDate, els.stoolTime); delete els.stoolDate.dataset.dirty; delete els.stoolTime.dataset.dirty; }
+          if (typeof window !== 'undefined' && typeof window.closeSheet === 'function') window.closeSheet('stoolSheet');
         }
         function getSelectedBristol(){
           const r = document.querySelector('input[name="stoolBristol"]:checked');


### PR DESCRIPTION
## Summary
- close the avföring planning sheet once a custom entry is added to return the user to the list view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1910754848333af6fa663076f01ec